### PR TITLE
Show help pop-up only for general help command

### DIFF
--- a/src/main/java/seedu/address/logic/commands/HelpCommand.java
+++ b/src/main/java/seedu/address/logic/commands/HelpCommand.java
@@ -27,7 +27,7 @@ public class HelpCommand extends Command {
         if (targetCommand.isEmpty()) {
             return new CommandResult(getAllCommandsUsage(), true, false);
         } else {
-            return new CommandResult(getCommandUsage(targetCommand), true, false);
+            return new CommandResult(getCommandUsage(targetCommand), false, false);
         }
     }
 

--- a/src/test/java/seedu/address/logic/commands/HelpCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/HelpCommandTest.java
@@ -29,14 +29,14 @@ public class HelpCommandTest {
 
     @Test
     public void execute_helpWithSpecificCommand_success() {
-        CommandResult expectedCommandResult = new CommandResult(AddCommand.MESSAGE_USAGE, true, false);
+        CommandResult expectedCommandResult = new CommandResult(AddCommand.MESSAGE_USAGE, false, false);
         assertCommandSuccess(new HelpCommand("add"), model, expectedCommandResult, expectedModel);
     }
 
     @Test
     public void execute_helpWithUnknownCommand_success() {
         String expectedMessage = "Unknown command: xyz\n\nType 'help' to see all available commands.";
-        CommandResult expectedCommandResult = new CommandResult(expectedMessage, true, false);
+        CommandResult expectedCommandResult = new CommandResult(expectedMessage, false, false);
         assertCommandSuccess(new HelpCommand("xyz"), model, expectedCommandResult, expectedModel);
     }
 }


### PR DESCRIPTION
help with specific commands (e.g., help add) now displays inline in the result display instead of opening a pop-up window. Closes #74 Closes #44 