### PR TITLE
Update constraints for `Location` objects

### DIFF
--- a/docs/UserGuide.md
+++ b/docs/UserGuide.md
@@ -98,7 +98,7 @@ Format: `add n/NAME g/GENDER dob/DATE_OF_BIRTH p/PHONE_NUMBER e/EMAIL_ADDRESS a/
 * `GENDER` must be either `M` or `F` (case-insensitive)
 * `DATE_OF_BIRTH` must follow the format 'DD/MM/YYYY'
 * `DATE_OF_BIRTH` must be a valid date, not in the future, and not more than 100 years in the past.
-* `LOCATION` can contain any value except values with the `/` symbol.
+* `LOCATION` can contain any value.
 * If `LOCATION` is omitted, the client is treated as having no specified location and the UI displays `N/A`.
 
 <box type="tip" seamless>
@@ -347,7 +347,7 @@ Format: `log INDEX [time/TIME] [l/LOCATION]`
 * `TIME` must be a valid date and time not in the future, nor more than 50 years in the past.
 * `TIME` must be in the format: "DD/MM/YYYY HH:mm"
 * If `TIME` is not declared, the current time will be used.
-* `LOCATION` can take on any value except values containing the `/` symbol.
+* `LOCATION` can take on any value.
 * If `LOCATION` is not specified, the client's preset location will be used.
 * If `LOCATION` is not specified and the client does not have a preset location, `N/A` will be used.
 

--- a/src/main/java/seedu/address/logic/parser/ParserUtil.java
+++ b/src/main/java/seedu/address/logic/parser/ParserUtil.java
@@ -144,9 +144,7 @@ public class ParserUtil {
     public static Location parseLocation(String location) throws ParseException {
         requireNonNull(location);
         String trimmedLocation = location.trim();
-        if (!Location.isValidLocation(trimmedLocation)) {
-            throw new ParseException(Location.MESSAGE_CONSTRAINTS);
-        }
+
         return new Location(trimmedLocation);
     }
 

--- a/src/main/java/seedu/address/model/person/Location.java
+++ b/src/main/java/seedu/address/model/person/Location.java
@@ -1,25 +1,17 @@
 package seedu.address.model.person;
 
 import static java.util.Objects.requireNonNull;
-import static seedu.address.commons.util.AppUtil.checkArgument;
 
 /**
  * Represents a client's preferred gym location in PowerRoster.
- * Guarantees: immutable; is valid as declared in
- * {@link #isValidLocation(String)}
+ * Guarantees: immutable;
  */
 public class Location {
     public static final String MESSAGE_CONSTRAINTS =
-        "Locations can take any value not containing the '/' symbol. "
+        "Locations can take any value. "
         + "Leave it blank to indicate no specified location.";
 
     public static final String EMPTY_LOCATION = "";
-
-    /**
-     * Location can take on any value as long as it does not contain
-     * the / symbol
-     */
-    public static final String VALIDATION_REGEX = "^[^/]*$";
 
     public final String value;
 
@@ -30,16 +22,7 @@ public class Location {
      */
     public Location(String location) {
         requireNonNull(location);
-        checkArgument(isValidLocation(location), MESSAGE_CONSTRAINTS);
         value = location;
-    }
-
-    /**
-     * Returns true if a given string is a valid location.
-     */
-    public static boolean isValidLocation(String test) {
-        requireNonNull(test);
-        return EMPTY_LOCATION.equals(test) || test.matches(VALIDATION_REGEX);
     }
 
     @Override

--- a/src/main/java/seedu/address/storage/JsonAdaptedPerson.java
+++ b/src/main/java/seedu/address/storage/JsonAdaptedPerson.java
@@ -190,9 +190,6 @@ class JsonAdaptedPerson {
             throw new IllegalValueException(
                     String.format(MISSING_FIELD_MESSAGE_FORMAT, Location.class.getSimpleName()));
         }
-        if (!location.isEmpty() && !Location.isValidLocation(location)) {
-            throw new IllegalValueException(Location.MESSAGE_CONSTRAINTS);
-        }
         final Location modelLocation = new Location(location);
 
         if (note == null) {

--- a/src/main/java/seedu/address/storage/JsonAdaptedWorkoutLog.java
+++ b/src/main/java/seedu/address/storage/JsonAdaptedWorkoutLog.java
@@ -73,9 +73,6 @@ public class JsonAdaptedWorkoutLog {
                     MISSING_FIELD_MESSAGE_FORMAT,
                     Location.class.getSimpleName()));
         }
-        if (!Location.isValidLocation(location)) {
-            throw new IllegalValueException(Location.MESSAGE_CONSTRAINTS);
-        }
         final Location modelLocation = new Location(location);
 
         return new WorkoutLog(modelTraineeId, modelTime, modelLocation);

--- a/src/test/java/seedu/address/logic/commands/CommandTestUtil.java
+++ b/src/test/java/seedu/address/logic/commands/CommandTestUtil.java
@@ -110,8 +110,6 @@ public class CommandTestUtil {
     public static final String INVALID_EMAIL_DESC = " " + PREFIX_EMAIL + "bob!yahoo";
     // empty string not allowed for addresses
     public static final String INVALID_ADDRESS_DESC = " " + PREFIX_ADDRESS;
-    // '/' symbol not allowed for locations
-    public static final String INVALID_LOCATION_DESC = " " + PREFIX_LOCATION + "Gym/Studio";
     // height out of valid range
     public static final String INVALID_HEIGHT_DESC = " " + PREFIX_HEIGHT + "49.9";
     // weight out of valid range

--- a/src/test/java/seedu/address/logic/parser/AddCommandParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/AddCommandParserTest.java
@@ -13,7 +13,6 @@ import static seedu.address.logic.commands.CommandTestUtil.INVALID_ADDRESS_DESC;
 import static seedu.address.logic.commands.CommandTestUtil.INVALID_DOB_DESC;
 import static seedu.address.logic.commands.CommandTestUtil.INVALID_EMAIL_DESC;
 import static seedu.address.logic.commands.CommandTestUtil.INVALID_GENDER_DESC;
-import static seedu.address.logic.commands.CommandTestUtil.INVALID_LOCATION_DESC;
 import static seedu.address.logic.commands.CommandTestUtil.INVALID_NAME_DESC;
 import static seedu.address.logic.commands.CommandTestUtil.INVALID_PHONE_DESC;
 import static seedu.address.logic.commands.CommandTestUtil.INVALID_TAG_DESC;
@@ -56,7 +55,6 @@ import seedu.address.model.person.Address;
 import seedu.address.model.person.DateOfBirth;
 import seedu.address.model.person.Email;
 import seedu.address.model.person.Gender;
-import seedu.address.model.person.Location;
 import seedu.address.model.person.Name;
 import seedu.address.model.person.Person;
 import seedu.address.model.person.Phone;
@@ -186,10 +184,6 @@ public class AddCommandParserTest {
         assertParseFailure(parser, INVALID_ADDRESS_DESC + validExpectedPersonString,
                 Messages.getErrorMessageForDuplicatePrefixes(PREFIX_ADDRESS));
 
-        // invalid location
-        assertParseFailure(parser, INVALID_LOCATION_DESC + validExpectedPersonString,
-                Messages.getErrorMessageForDuplicatePrefixes(PREFIX_LOCATION));
-
         // valid value followed by invalid value
 
         // invalid name
@@ -215,10 +209,6 @@ public class AddCommandParserTest {
         // invalid address
         assertParseFailure(parser, validExpectedPersonString + INVALID_ADDRESS_DESC,
                 Messages.getErrorMessageForDuplicatePrefixes(PREFIX_ADDRESS));
-
-        // invalid location
-        assertParseFailure(parser, validExpectedPersonString + INVALID_LOCATION_DESC,
-                Messages.getErrorMessageForDuplicatePrefixes(PREFIX_LOCATION));
     }
 
     @Test
@@ -440,19 +430,6 @@ public class AddCommandParserTest {
                 + TAG_DESC_HUSBAND
                 + TAG_DESC_FRIEND,
                 Address.MESSAGE_CONSTRAINTS);
-
-        // invalid location
-        assertParseFailure(parser,
-                NAME_DESC_BOB
-                + GENDER_DESC_BOB
-                + DOB_DESC_BOB
-                + PHONE_DESC_BOB
-                + EMAIL_DESC_BOB
-                + ADDRESS_DESC_BOB
-                + INVALID_LOCATION_DESC
-                + TAG_DESC_HUSBAND
-                + TAG_DESC_FRIEND,
-                Location.MESSAGE_CONSTRAINTS);
 
         // invalid tag
         assertParseFailure(parser,

--- a/src/test/java/seedu/address/model/person/LocationTest.java
+++ b/src/test/java/seedu/address/model/person/LocationTest.java
@@ -14,29 +14,8 @@ public class LocationTest {
     }
 
     @Test
-    public void constructor_invalidLocation_throwsIllegalArgumentException() {
-        String invalidLocation = "Home/Gym";
-        assertThrows(IllegalArgumentException.class, () -> new Location(invalidLocation));
-    }
-
-    @Test
     public void constructor_emptyLocation_success() {
         assertTrue(new Location("").value.isEmpty());
-    }
-
-    @Test
-    public void isValidLocation() {
-        // null Location
-        assertThrows(NullPointerException.class, () -> Location.isValidLocation(null));
-
-        // invalid Locations
-        assertFalse(Location.isValidLocation("/")); // '/' symbol invalid
-
-        // valid Locations
-        assertTrue(Location.isValidLocation("")); // empty string
-        assertTrue(Location.isValidLocation("Anytime Fitness Marine Parade"));
-        assertTrue(Location.isValidLocation("B")); // one character
-        assertTrue(Location.isValidLocation("ActiveSG Gym @ Fernvale Square")); // contains @ symbol
     }
 
     @Test

--- a/src/test/java/seedu/address/storage/JsonAdaptedPersonTest.java
+++ b/src/test/java/seedu/address/storage/JsonAdaptedPersonTest.java
@@ -35,7 +35,6 @@ public class JsonAdaptedPersonTest {
     private static final String INVALID_DOB = "25-7-12";
     private static final String INVALID_PHONE = "++651234";
     private static final String INVALID_ADDRESS = " ";
-    private static final String INVALID_LOCATION = "/";
     private static final String INVALID_EMAIL = "example.com";
     private static final String INVALID_PLAN = "   ";
     private static final String INVALID_TAG = "#friend";
@@ -385,29 +384,6 @@ public class JsonAdaptedPersonTest {
                 VALID_BODY_FAT,
                 VALID_TAGS);
         String expectedMessage = String.format(MISSING_FIELD_MESSAGE_FORMAT, Address.class.getSimpleName());
-        assertThrows(IllegalValueException.class, expectedMessage, person::toModelType);
-    }
-
-    @Test
-    public void toModelType_invalidLocation_throwsIllegalValueException() {
-        JsonAdaptedPerson person = new JsonAdaptedPerson(
-                VALID_ID,
-                VALID_NAME,
-                VALID_GENDER,
-                VALID_DOB,
-                VALID_PHONE,
-                VALID_EMAIL,
-                VALID_ADDRESS,
-                INVALID_LOCATION,
-                VALID_NOTE,
-                VALID_PLAN,
-                VALID_RATE,
-                VALID_STATUS,
-                VALID_HEIGHT,
-                VALID_WEIGHT,
-                VALID_BODY_FAT,
-                VALID_TAGS);
-        String expectedMessage = Location.MESSAGE_CONSTRAINTS;
         assertThrows(IllegalValueException.class, expectedMessage, person::toModelType);
     }
 

--- a/src/test/java/seedu/address/storage/JsonAdaptedWorkoutLogTest.java
+++ b/src/test/java/seedu/address/storage/JsonAdaptedWorkoutLogTest.java
@@ -16,7 +16,6 @@ public class JsonAdaptedWorkoutLogTest {
 
     private static final String INVALID_ID = "345hjj5-345-GFNJ";
     private static final String INVALID_TIME = "23-01-25 0900";
-    private static final String INVALID_LOCATION = "/";
 
     private static final String VALID_ID = BENSON_LOG_1.getTrainee().toString();
     private static final String VALID_TIME = BENSON_LOG_1.getTime().toString();
@@ -64,15 +63,6 @@ public class JsonAdaptedWorkoutLogTest {
                 null,
                 VALID_LOCATION);
         String expectedMessage = String.format(MISSING_FIELD_MESSAGE_FORMAT, WorkoutTime.class.getSimpleName());;
-        assertThrows(IllegalValueException.class, expectedMessage, log::toModelType);
-    }
-    @Test
-    public void toModelType_invalidLocation_throwsIllegalValueException() {
-        JsonAdaptedWorkoutLog log = new JsonAdaptedWorkoutLog(
-                VALID_ID,
-                VALID_TIME,
-                INVALID_LOCATION);
-        String expectedMessage = Location.MESSAGE_CONSTRAINTS;
         assertThrows(IllegalValueException.class, expectedMessage, log::toModelType);
     }
 


### PR DESCRIPTION
This pull request does the following:

Changes constraints on `Location` objects to only block `/` symbols so as to allow for some valid real world locations that were previously not permissible by PowerRoster
- Closes #175 

Adds `Location` constraints into User Guide
- Closes #173 