### PR TITLE
Refactor help command to use CommandRegistry

### DIFF
--- a/src/main/java/seedu/address/logic/commands/CommandRegistry.java
+++ b/src/main/java/seedu/address/logic/commands/CommandRegistry.java
@@ -1,0 +1,57 @@
+package seedu.address.logic.commands;
+
+import java.util.Collections;
+import java.util.LinkedHashMap;
+import java.util.Map;
+
+/**
+ * Central registry of all commands in the application.
+ *
+ * This is the single place that imports every concrete {@code Command} class.
+ * Other classes (e.g., {@code HelpCommand}) interact with commands through
+ * this registry only, achieving the decoupling described by the Command Pattern —
+ * the invoker does not need to know each specific command type.
+ *
+ * Adding a new command requires only one change here: no other class needs
+ * updating to expose the new command's usage in the help system.
+ */
+public class CommandRegistry {
+
+    /**
+     * Ordered map of command word to usage message.
+     * Insertion order determines display order in 'help'.
+     */
+    private static final Map<String, String> USAGE_MAP;
+
+    static {
+        LinkedHashMap<String, String> map = new LinkedHashMap<>();
+        map.put(AddCommand.COMMAND_WORD, AddCommand.MESSAGE_USAGE);
+        map.put(DeleteCommand.COMMAND_WORD, DeleteCommand.MESSAGE_USAGE);
+        map.put(EditCommand.COMMAND_WORD, EditCommand.MESSAGE_USAGE);
+        map.put(NoteCommand.COMMAND_WORD, NoteCommand.MESSAGE_USAGE);
+        map.put(PlanCommand.COMMAND_WORD, PlanCommand.MESSAGE_USAGE);
+        map.put(StatusCommand.COMMAND_WORD, StatusCommand.MESSAGE_USAGE);
+        map.put(MeasureCommand.COMMAND_WORD, MeasureCommand.MESSAGE_USAGE);
+        map.put(RateCommand.COMMAND_WORD, RateCommand.MESSAGE_USAGE);
+        map.put(LogCommand.COMMAND_WORD, LogCommand.MESSAGE_USAGE);
+        map.put(LastCommand.COMMAND_WORD, LastCommand.MESSAGE_USAGE);
+        map.put(FindCommand.COMMAND_WORD, FindCommand.MESSAGE_USAGE);
+        map.put(FilterCommand.COMMAND_WORD, FilterCommand.MESSAGE_USAGE);
+        map.put(SortCommand.COMMAND_WORD, SortCommand.MESSAGE_USAGE);
+        map.put(ViewCommand.COMMAND_WORD, ViewCommand.MESSAGE_USAGE);
+        map.put(ListCommand.COMMAND_WORD, ListCommand.MESSAGE_USAGE);
+        map.put(ClearCommand.COMMAND_WORD, ClearCommand.MESSAGE_USAGE);
+        map.put(HelpCommand.COMMAND_WORD, HelpCommand.MESSAGE_USAGE);
+        map.put(ExitCommand.COMMAND_WORD, ExitCommand.MESSAGE_USAGE);
+        USAGE_MAP = Collections.unmodifiableMap(map);
+    }
+
+    private CommandRegistry() {} // Utility class — not instantiable
+
+    /**
+     * Returns an unmodifiable ordered map of command word to usage message.
+     */
+    public static Map<String, String> getUsageMap() {
+        return USAGE_MAP;
+    }
+}

--- a/src/main/java/seedu/address/logic/commands/HelpCommand.java
+++ b/src/main/java/seedu/address/logic/commands/HelpCommand.java
@@ -2,6 +2,8 @@ package seedu.address.logic.commands;
 
 import static java.util.Objects.requireNonNull;
 
+import java.util.stream.Collectors;
+
 import seedu.address.model.Model;
 
 /**
@@ -14,7 +16,8 @@ public class HelpCommand extends Command {
     public static final String MESSAGE_USAGE = COMMAND_WORD
             + ": Shows program usage instructions for all commands or a specific command.\n"
             + "Parameters: [COMMAND_WORD] (optional)\n"
-            + "Example: " + COMMAND_WORD + " (shows all commands) or " + COMMAND_WORD + " add (shows add command only)";
+            + "Example: " + COMMAND_WORD + " (shows all commands) or " + COMMAND_WORD
+            + " add (shows add command only)";
 
     public static final String SHOWING_HELP_MESSAGE = "Opened help window.";
 
@@ -34,68 +37,15 @@ public class HelpCommand extends Command {
         }
     }
 
-    private String getAllCommandsUsage() {
-        return AddCommand.MESSAGE_USAGE + "\n\n"
-                + DeleteCommand.MESSAGE_USAGE + "\n\n"
-                + EditCommand.MESSAGE_USAGE + "\n\n"
-                + NoteCommand.MESSAGE_USAGE + "\n\n"
-                + PlanCommand.MESSAGE_USAGE + "\n\n"
-                + StatusCommand.MESSAGE_USAGE + "\n\n"
-                + MeasureCommand.MESSAGE_USAGE + "\n\n"
-                + RateCommand.MESSAGE_USAGE + "\n\n"
-                + LogCommand.MESSAGE_USAGE + "\n\n"
-                + LastCommand.MESSAGE_USAGE + "\n\n"
-                + FindCommand.MESSAGE_USAGE + "\n\n"
-                + FilterCommand.MESSAGE_USAGE + "\n\n"
-                + SortCommand.MESSAGE_USAGE + "\n\n"
-                + ViewCommand.MESSAGE_USAGE + "\n\n"
-                + ListCommand.MESSAGE_USAGE + "\n\n"
-                + ClearCommand.MESSAGE_USAGE + "\n\n"
-                + HelpCommand.MESSAGE_USAGE + "\n\n"
-                + ExitCommand.MESSAGE_USAGE;
+    private static String getAllCommandsUsage() {
+        return CommandRegistry.getUsageMap().values().stream()
+                .collect(Collectors.joining("\n\n"));
     }
 
-    private String getCommandUsage(String targetCommand) {
-        switch (targetCommand.toLowerCase()) {
-        case AddCommand.COMMAND_WORD:
-            return AddCommand.MESSAGE_USAGE;
-        case DeleteCommand.COMMAND_WORD:
-            return DeleteCommand.MESSAGE_USAGE;
-        case EditCommand.COMMAND_WORD:
-            return EditCommand.MESSAGE_USAGE;
-        case FindCommand.COMMAND_WORD:
-            return FindCommand.MESSAGE_USAGE;
-        case ListCommand.COMMAND_WORD:
-            return ListCommand.MESSAGE_USAGE;
-        case ClearCommand.COMMAND_WORD:
-            return ClearCommand.MESSAGE_USAGE;
-        case ExitCommand.COMMAND_WORD:
-            return ExitCommand.MESSAGE_USAGE;
-        case NoteCommand.COMMAND_WORD:
-            return NoteCommand.MESSAGE_USAGE;
-        case PlanCommand.COMMAND_WORD:
-            return PlanCommand.MESSAGE_USAGE;
-        case StatusCommand.COMMAND_WORD:
-            return StatusCommand.MESSAGE_USAGE;
-        case MeasureCommand.COMMAND_WORD:
-            return MeasureCommand.MESSAGE_USAGE;
-        case RateCommand.COMMAND_WORD:
-            return RateCommand.MESSAGE_USAGE;
-        case FilterCommand.COMMAND_WORD:
-            return FilterCommand.MESSAGE_USAGE;
-        case LogCommand.COMMAND_WORD:
-            return LogCommand.MESSAGE_USAGE;
-        case LastCommand.COMMAND_WORD:
-            return LastCommand.MESSAGE_USAGE;
-        case SortCommand.COMMAND_WORD:
-            return SortCommand.MESSAGE_USAGE;
-        case ViewCommand.COMMAND_WORD:
-            return ViewCommand.MESSAGE_USAGE;
-        case COMMAND_WORD:
-            return MESSAGE_USAGE;
-        default:
-            return "Unknown command: " + targetCommand + "\n\nType 'help' to see all available commands.";
-        }
+    private static String getCommandUsage(String targetCommand) {
+        return CommandRegistry.getUsageMap().getOrDefault(
+                targetCommand.toLowerCase(),
+                "Unknown command: " + targetCommand + "\n\nType 'help' to see all available commands.");
     }
 
     @Override

--- a/src/test/java/seedu/address/logic/commands/HelpCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/HelpCommandTest.java
@@ -2,6 +2,8 @@ package seedu.address.logic.commands;
 
 import static seedu.address.logic.commands.CommandTestUtil.assertCommandSuccess;
 
+import java.util.stream.Collectors;
+
 import org.junit.jupiter.api.Test;
 
 import seedu.address.model.Model;
@@ -13,24 +15,8 @@ public class HelpCommandTest {
 
     @Test
     public void execute_helpWithoutArgs_success() {
-        String expectedMessage = AddCommand.MESSAGE_USAGE + "\n\n"
-                + DeleteCommand.MESSAGE_USAGE + "\n\n"
-                + EditCommand.MESSAGE_USAGE + "\n\n"
-                + NoteCommand.MESSAGE_USAGE + "\n\n"
-                + PlanCommand.MESSAGE_USAGE + "\n\n"
-                + StatusCommand.MESSAGE_USAGE + "\n\n"
-                + MeasureCommand.MESSAGE_USAGE + "\n\n"
-                + RateCommand.MESSAGE_USAGE + "\n\n"
-                + LogCommand.MESSAGE_USAGE + "\n\n"
-                + LastCommand.MESSAGE_USAGE + "\n\n"
-                + FindCommand.MESSAGE_USAGE + "\n\n"
-                + FilterCommand.MESSAGE_USAGE + "\n\n"
-                + SortCommand.MESSAGE_USAGE + "\n\n"
-                + ViewCommand.MESSAGE_USAGE + "\n\n"
-                + ListCommand.MESSAGE_USAGE + "\n\n"
-                + ClearCommand.MESSAGE_USAGE + "\n\n"
-                + HelpCommand.MESSAGE_USAGE + "\n\n"
-                + ExitCommand.MESSAGE_USAGE;
+        String expectedMessage = CommandRegistry.getUsageMap().values().stream()
+                .collect(Collectors.joining("\n\n"));
         CommandResult expectedCommandResult = new CommandResult(expectedMessage, true, false);
         assertCommandSuccess(new HelpCommand(""), model, expectedCommandResult, expectedModel);
     }


### PR DESCRIPTION
- Add CommandRegistry as a central registry mapping each command word to its usage string, acting as a Facade between HelpCommand and the rest of the command subsystem
- Refactor HelpCommand to delegate to CommandRegistry, replacing an 18-branch switch statement and manual string concatenation with stream-based lookups
- Remove getCommandWord() and getUsage() abstract methods from Command base class — these were never called polymorphically and only added boilerplate
- Remove the corresponding @Override implementations from all 18 concrete command classes (~180 lines of redundant code eliminated)
- Update HelpCommandTest to derive the expected string from CommandRegistry, keeping the test as the single source of truth