### PR TITLE
Separate error messages for WorkoutTime and DateOfBirth

### DIFF
--- a/src/main/java/seedu/address/logic/parser/ParserUtil.java
+++ b/src/main/java/seedu/address/logic/parser/ParserUtil.java
@@ -3,6 +3,7 @@ package seedu.address.logic.parser;
 import static java.util.Objects.requireNonNull;
 
 import java.time.LocalDate;
+import java.time.LocalDateTime;
 import java.time.format.DateTimeParseException;
 import java.util.Collection;
 import java.util.HashSet;
@@ -269,8 +270,13 @@ public class ParserUtil {
     public static WorkoutTime parseTime(String time) throws ParseException {
         requireNonNull(time);
         String trimmedTime = time.trim();
-        if (!WorkoutTime.isValidTime(trimmedTime)) {
-            throw new ParseException(WorkoutTime.MESSAGE_CONSTRAINTS);
+        try {
+            LocalDateTime testDateTime = LocalDateTime.parse(trimmedTime, WorkoutTime.FORMATTER);
+            if (!WorkoutTime.isValidTimeframe(testDateTime)) {
+                throw new ParseException(WorkoutTime.MESSAGE_INVALID_TIMEFRAME);
+            }
+        } catch (DateTimeParseException e) {
+            throw new ParseException(WorkoutTime.MESSAGE_INVALID_DATETIME);
         }
         return new WorkoutTime(trimmedTime);
     }

--- a/src/main/java/seedu/address/logic/parser/ParserUtil.java
+++ b/src/main/java/seedu/address/logic/parser/ParserUtil.java
@@ -2,6 +2,8 @@ package seedu.address.logic.parser;
 
 import static java.util.Objects.requireNonNull;
 
+import java.time.LocalDate;
+import java.time.format.DateTimeParseException;
 import java.util.Collection;
 import java.util.HashSet;
 import java.util.Set;
@@ -99,8 +101,13 @@ public class ParserUtil {
     public static DateOfBirth parseDateOfBirth(String dob) throws ParseException {
         requireNonNull(dob);
         String trimmedDob = dob.trim();
-        if (!DateOfBirth.isValidDob(trimmedDob)) {
-            throw new ParseException(DateOfBirth.MESSAGE_CONSTRAINTS);
+        try {
+            LocalDate testDate = LocalDate.parse(trimmedDob, DateOfBirth.FORMATTER);
+            if (!DateOfBirth.isValidTimeframe(testDate)) {
+                throw new ParseException(DateOfBirth.MESSAGE_INVALID_TIMEFRAME);
+            }
+        } catch (DateTimeParseException e) {
+            throw new ParseException(DateOfBirth.MESSAGE_INVALID_DATE);
         }
         return new DateOfBirth(trimmedDob);
     }

--- a/src/main/java/seedu/address/model/person/DateOfBirth.java
+++ b/src/main/java/seedu/address/model/person/DateOfBirth.java
@@ -17,6 +17,11 @@ public class DateOfBirth {
             "Date of Birth must be a valid date in the format DD/MM/YYYY\n"
             + "Date of Birth cannot be in the future or more than 100 years in the past.";
 
+    public static final String MESSAGE_INVALID_DATE = "Date of Birth must be a valid date in the format DD/MM/YYYY";
+
+    public static final String MESSAGE_INVALID_TIMEFRAME =
+            "Date of Birth cannot be in the future or more than 100 years in the past.";
+
     public static final DateTimeFormatter FORMATTER = DateTimeFormatter.ofPattern("dd/MM/uuuu")
             .withResolverStyle(ResolverStyle.STRICT);
 
@@ -39,16 +44,21 @@ public class DateOfBirth {
         boolean isValidDate = true;
         try {
             LocalDate testDate = LocalDate.parse(test, DateOfBirth.FORMATTER);
-            if (testDate.isAfter(LocalDate.now())) {
-                isValidDate = false;
-            }
-            if (testDate.isBefore(LocalDate.now().minusYears(100))) {
+            if (!isValidTimeframe(testDate)) {
                 isValidDate = false;
             }
         } catch (DateTimeParseException e) {
             isValidDate = false;
         }
         return isValidDate;
+    }
+
+    /**
+     * Returns true if the given {@code LocalDate} object is between now
+     * and 100 years in the past.
+     */
+    public static boolean isValidTimeframe(LocalDate testDate) {
+        return !testDate.isAfter(LocalDate.now()) && !testDate.isBefore(LocalDate.now().minusYears(100));
     }
 
     @Override

--- a/src/main/java/seedu/address/model/workout/WorkoutTime.java
+++ b/src/main/java/seedu/address/model/workout/WorkoutTime.java
@@ -17,6 +17,12 @@ public class WorkoutTime {
             "Workout Time must be a valid date in the format: dd/MM/yyyy HH:mm\n"
             + "Workout Time cannot be in the future or more than 50 years in the past.";
 
+    public static final String MESSAGE_INVALID_DATETIME =
+            "Workout Time must be a valid date in the format: dd/MM/yyyy HH:mm";
+
+    public static final String MESSAGE_INVALID_TIMEFRAME =
+            "Workout Time cannot be in the future or more than 50 years in the past.";
+
     public static final DateTimeFormatter FORMATTER = DateTimeFormatter.ofPattern("dd/MM/uuuu HH:mm")
             .withResolverStyle(ResolverStyle.STRICT);
 
@@ -42,17 +48,18 @@ public class WorkoutTime {
     public static boolean isValidTime(String test) {
         try {
             LocalDateTime parsed = LocalDateTime.parse(test, FORMATTER);
-            if (parsed.isAfter(LocalDateTime.now())) {
-                return false;
-            }
-            LocalDateTime threshold = LocalDateTime.now().minusYears(50);
-            if (parsed.isBefore(threshold)) {
-                return false;
-            }
-            return true;
+            return isValidTimeframe(parsed);
         } catch (DateTimeParseException e) {
             return false;
         }
+    }
+
+    /**
+     * Returns true if the given {@code LocalDateTime} object is
+     * not in the future and not more than 50 years in the past.
+     */
+    public static boolean isValidTimeframe(LocalDateTime testDateTime) {
+        return !testDateTime.isAfter(LocalDateTime.now()) && !testDateTime.isBefore(LocalDateTime.now().minusYears(50));
     }
 
     public LocalDateTime getTime() {

--- a/src/test/java/seedu/address/logic/parser/AddCommandParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/AddCommandParserTest.java
@@ -390,7 +390,7 @@ public class AddCommandParserTest {
                 + LOCATION_DESC_BOB
                 + TAG_DESC_HUSBAND
                 + TAG_DESC_FRIEND,
-                DateOfBirth.MESSAGE_CONSTRAINTS);
+                DateOfBirth.MESSAGE_INVALID_DATE);
 
         // invalid phone
         assertParseFailure(parser,


### PR DESCRIPTION
This pull request does the following:
- Separates messages pertaining to invalid date/datetimes (invalid format/non-existent date) and messages pertaining to dates/datetimes falling outside of the alloted boundaries
- Differentiates the kind of error found in inputs and only outputs the appropriate error message

Closes #372 Closes #355 Closes #371 Closes #353 Closes #319
