### PR TITLE
Fix conditions under which Sample Workout Log data is used

### DIFF
--- a/src/main/java/seedu/address/MainApp.java
+++ b/src/main/java/seedu/address/MainApp.java
@@ -95,7 +95,7 @@ public class MainApp extends Application {
             initialData = addressBookOptional.orElseGet(SampleDataUtil::getSampleAddressBook);
         } catch (DataLoadingException e) {
             logger.warning("Data file at " + storage.getAddressBookFilePath() + " could not be loaded."
-                    + " Will be starting with an empty AddressBook");
+                    + " Will be starting with an empty AddressBook.");
             initialData = new AddressBook();
         }
 

--- a/src/main/java/seedu/address/MainApp.java
+++ b/src/main/java/seedu/address/MainApp.java
@@ -95,7 +95,7 @@ public class MainApp extends Application {
             initialData = addressBookOptional.orElseGet(SampleDataUtil::getSampleAddressBook);
         } catch (DataLoadingException e) {
             logger.warning("Data file at " + storage.getAddressBookFilePath() + " could not be loaded."
-                    + " Will be starting with an empty AddressBook and WorkoutLogBook");
+                    + " Will be starting with an empty AddressBook");
             initialData = new AddressBook();
         }
 

--- a/src/main/java/seedu/address/MainApp.java
+++ b/src/main/java/seedu/address/MainApp.java
@@ -108,7 +108,7 @@ public class MainApp extends Application {
                 initialLogs = SampleDataUtil.getSampleWorkoutLogBook();
             } else if (!workoutLogBookOptional.isPresent() && isAddressBookPresent) {
                 logger.info("AddressBook detected but no WorkoutLogBook detected."
-                        + "Starting with empty WorkoutLogBook");
+                        + " Starting with empty WorkoutLogBook");
                 initialLogs = new WorkoutLogBook();
             } else {
                 initialLogs = workoutLogBookOptional.get();

--- a/src/main/java/seedu/address/MainApp.java
+++ b/src/main/java/seedu/address/MainApp.java
@@ -84,16 +84,18 @@ public class MainApp extends Application {
 
         Optional<ReadOnlyAddressBook> addressBookOptional;
         ReadOnlyAddressBook initialData;
+        boolean isAddressBookPresent = true;
         try {
             addressBookOptional = storage.readAddressBook();
             if (!addressBookOptional.isPresent()) {
+                isAddressBookPresent = false;
                 logger.info("Creating a new data file " + storage.getAddressBookFilePath()
                         + " populated with a sample AddressBook.");
             }
             initialData = addressBookOptional.orElseGet(SampleDataUtil::getSampleAddressBook);
         } catch (DataLoadingException e) {
             logger.warning("Data file at " + storage.getAddressBookFilePath() + " could not be loaded."
-                    + " Will be starting with an empty AddressBook.");
+                    + " Will be starting with an empty AddressBook and WorkoutLogBook");
             initialData = new AddressBook();
         }
 
@@ -101,10 +103,16 @@ public class MainApp extends Application {
         WorkoutLogBook initialLogs;
         try {
             workoutLogBookOptional = storage.readWorkoutLogBook();
-            if (!workoutLogBookOptional.isPresent()) {
+            if (!workoutLogBookOptional.isPresent() && !isAddressBookPresent) {
                 logger.info("Creating new workout log file " + storage.getWorkoutLogBookFilePath());
+                initialLogs = SampleDataUtil.getSampleWorkoutLogBook();
+            } else if (!workoutLogBookOptional.isPresent() && isAddressBookPresent) {
+                logger.info("AddressBook detected but no WorkoutLogBook detected."
+                        + "Starting with empty WorkoutLogBook");
+                initialLogs = new WorkoutLogBook();
+            } else {
+                initialLogs = workoutLogBookOptional.get();
             }
-            initialLogs = workoutLogBookOptional.orElseGet(SampleDataUtil::getSampleWorkoutLogBook);
         } catch (DataLoadingException e) {
             logger.warning("Workout Log File at " + storage.getWorkoutLogBookFilePath() + " could not be loaded."
                 + " Will be starting with empty workout log book.");


### PR DESCRIPTION
This pull request does the following:
- Changes the conditions under which Sample Data is used for workout logs
  - If addressbook is present but no workout logs are present, starts with empty workoutlog book
  - If addressbook is absent and no workout logs are present, starts with sample data
- Treats a corrupted addressbook as if it is present

Closes #335 