### PR TITLE
Fix PE-D bugs: sort preamble validation, phone sort order, person/client terminology, and add command spacing

### DIFF
--- a/src/main/java/seedu/address/logic/commands/AddCommand.java
+++ b/src/main/java/seedu/address/logic/commands/AddCommand.java
@@ -28,7 +28,7 @@ public class AddCommand extends Command {
     public static final String MESSAGE_USAGE = COMMAND_WORD + ": Adds a client to PowerRoster.\n"
             + "Parameters: " + PREFIX_NAME + "NAME " + PREFIX_GENDER + "GENDER " + PREFIX_DOB
             + "DOB " + PREFIX_PHONE + "PHONE " + PREFIX_EMAIL + "EMAIL " + PREFIX_ADDRESS
-            + "ADDRESS " + "[" + PREFIX_LOCATION + "LOCATION]" + "[" + PREFIX_TAG + "TAG]...\n"
+            + "ADDRESS " + "[" + PREFIX_LOCATION + "LOCATION] " + "[" + PREFIX_TAG + "TAG]...\n"
             + "Example: " + COMMAND_WORD + " " + PREFIX_NAME + "John Tan " + PREFIX_GENDER + "M "
             + PREFIX_DOB + "24/12/1999 " + PREFIX_PHONE + "98765432 " + PREFIX_EMAIL
             + "johnt@example.com " + PREFIX_ADDRESS + "123 Sengkang East, #01-01 " + PREFIX_LOCATION

--- a/src/main/java/seedu/address/logic/commands/DeleteCommand.java
+++ b/src/main/java/seedu/address/logic/commands/DeleteCommand.java
@@ -20,7 +20,7 @@ public class DeleteCommand extends Command {
     public static final String COMMAND_WORD = "delete";
 
     public static final String MESSAGE_USAGE = COMMAND_WORD
-            + ": Deletes the person identified by the index number used in the displayed person list.\n"
+            + ": Deletes the client identified by the index number used in the displayed client list.\n"
             + "Parameters: INDEX (must be a positive integer)\n" + "Example: " + COMMAND_WORD
             + " 1";
 

--- a/src/main/java/seedu/address/logic/commands/FindCommand.java
+++ b/src/main/java/seedu/address/logic/commands/FindCommand.java
@@ -18,7 +18,7 @@ public class FindCommand extends Command {
     public static final String COMMAND_WORD = "find";
 
     public static final String MESSAGE_USAGE = COMMAND_WORD
-            + ": Finds all persons whose names contain any of "
+            + ": Finds all clients whose names contain any of "
             + "the specified keywords (case-insensitive) and displays them as a list with index numbers.\n"
             + "Parameters: KEYWORD [MORE_KEYWORDS]...\n" + "Example: " + COMMAND_WORD
             + " alice bob charlie";

--- a/src/main/java/seedu/address/logic/commands/LogCommand.java
+++ b/src/main/java/seedu/address/logic/commands/LogCommand.java
@@ -28,7 +28,7 @@ public class LogCommand extends Command {
     public static final String COMMAND_WORD = "log";
 
     public static final String MESSAGE_USAGE = COMMAND_WORD
-            + ": Logs a workout for the person identified by the index number used in the displayed client list\n"
+            + ": Logs a workout for the client identified by the index number used in the displayed client list\n"
             + "Parameters: " + "INDEX (must be a positive integer) " + "[" + PREFIX_TIME + "TIME] "
             + "[" + PREFIX_LOCATION + "LOCATION]";
 

--- a/src/main/java/seedu/address/logic/commands/StatusCommand.java
+++ b/src/main/java/seedu/address/logic/commands/StatusCommand.java
@@ -22,13 +22,13 @@ public class StatusCommand extends Command {
     public static final String COMMAND_WORD = "status";
 
     public static final String MESSAGE_USAGE = COMMAND_WORD
-            + ": Changes the status of the person identified by the index number used in the displayed person list.\n"
+            + ": Changes the status of the client identified by the index number used in the displayed client list.\n"
             + "Parameters: INDEX (must be a positive integer) "
             + PREFIX_STATUS + "STATUS (must be 'active' or 'inactive')\n"
             + "Example: " + COMMAND_WORD + " 1 " + PREFIX_STATUS + "inactive";
 
-    public static final String MESSAGE_STATUS_PERSON_SUCCESS = "Updated status of Person: %1$s";
-    public static final String MESSAGE_NOT_CHANGED = "Status is already set to %1$s for person: %2$s";
+    public static final String MESSAGE_STATUS_PERSON_SUCCESS = "Updated status of Client: %1$s";
+    public static final String MESSAGE_NOT_CHANGED = "Status is already set to %1$s for client: %2$s";
     public static final String MESSAGE_DUPLICATE_STATUS =
             "Only one status value (either active or inactive) can be specified.";
 

--- a/src/main/java/seedu/address/logic/commands/ViewCommand.java
+++ b/src/main/java/seedu/address/logic/commands/ViewCommand.java
@@ -22,8 +22,8 @@ public class ViewCommand extends Command {
     public static final String COMMAND_WORD = "view";
 
     public static final String MESSAGE_USAGE = COMMAND_WORD
-            + ": Displays the full details of the person identified by the index number"
-            + " used in the displayed person list.\n"
+            + ": Displays the full details of the client identified by the index number"
+            + " used in the displayed client list.\n"
             + "Parameters: INDEX (must be a positive integer)\n" + "Example: " + COMMAND_WORD
             + " 1";
 

--- a/src/main/java/seedu/address/logic/parser/SortCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/SortCommandParser.java
@@ -71,6 +71,11 @@ public class SortCommandParser implements Parser<SortCommand> {
                 PREFIX_EMAIL, PREFIX_ADDRESS, PREFIX_LOCATION, PREFIX_ORDER,
                 PREFIX_STATUS, PREFIX_PLAN, PREFIX_RATE);
 
+        if (!argMultimap.getPreamble().isEmpty()) {
+            throw new ParseException(
+                    String.format(MESSAGE_INVALID_COMMAND_FORMAT, SortCommand.MESSAGE_USAGE));
+        }
+
         argMultimap.verifyNoDuplicatePrefixesFor(PREFIX_ORDER,
                 PREFIX_NAME, PREFIX_GENDER, PREFIX_DOB, PREFIX_PHONE,
                 PREFIX_EMAIL, PREFIX_ADDRESS, PREFIX_LOCATION,

--- a/src/main/java/seedu/address/model/person/PersonComparators.java
+++ b/src/main/java/seedu/address/model/person/PersonComparators.java
@@ -76,7 +76,8 @@ public class PersonComparators {
             return firstLocation.compareToIgnoreCase(secondLocation);
         });
         COMPARATORS.put(ATTRIBUTE_DOB, Comparator.comparing(p -> p.getDateOfBirth().value));
-        COMPARATORS.put(ATTRIBUTE_PHONE, Comparator.comparing(p -> p.getPhone().value));
+        COMPARATORS.put(ATTRIBUTE_PHONE, Comparator.comparingLong((Person p) ->
+                Long.parseLong(p.getPhone().value.replace("+", ""))));
         COMPARATORS.put(ATTRIBUTE_EMAIL, Comparator.comparing(p -> p.getEmail().value.toLowerCase()));
         COMPARATORS.put(ATTRIBUTE_ADDRESS, Comparator.comparing(p -> p.getAddress().value.toLowerCase()));
         COMPARATORS.put(ATTRIBUTE_GENDER, Comparator.comparing(p -> p.getGender().value.name()));

--- a/src/main/java/seedu/address/storage/JsonAdaptedPerson.java
+++ b/src/main/java/seedu/address/storage/JsonAdaptedPerson.java
@@ -33,7 +33,7 @@ import seedu.address.model.tag.Tag;
  */
 class JsonAdaptedPerson {
 
-    public static final String MISSING_FIELD_MESSAGE_FORMAT = "Person's %s field is missing!";
+    public static final String MISSING_FIELD_MESSAGE_FORMAT = "Client's %s field is missing!";
 
     private final String id;
     private final String name;

--- a/src/main/java/seedu/address/storage/JsonSerializableAddressBook.java
+++ b/src/main/java/seedu/address/storage/JsonSerializableAddressBook.java
@@ -19,7 +19,7 @@ import seedu.address.model.person.Person;
 @JsonRootName(value = "addressbook")
 class JsonSerializableAddressBook {
 
-    public static final String MESSAGE_DUPLICATE_PERSON = "Persons list contains duplicate person(s).";
+    public static final String MESSAGE_DUPLICATE_PERSON = "Clients list contains duplicate client(s).";
 
     private final List<JsonAdaptedPerson> persons = new ArrayList<>();
 

--- a/src/test/java/seedu/address/logic/commands/SortCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/SortCommandTest.java
@@ -178,9 +178,9 @@ public class SortCommandTest {
         SortCommand command = new SortCommand("phone", "asc");
         expectedModel.updatePersonListComparator(phoneComparator);
         assertCommandSuccess(command, model, expectedMessage, expectedModel);
-        // DANIEL (87652533), ELLE (9482224), FIONA (9482427), GEORGE (9482442),
+        // ELLE (9482224), FIONA (9482427), GEORGE (9482442), DANIEL (87652533),
         // ALICE (94351253), CARL (95352563), BENSON (98765432)
-        assertEquals(Arrays.asList(DANIEL, ELLE, FIONA, GEORGE, ALICE, CARL, BENSON),
+        assertEquals(Arrays.asList(ELLE, FIONA, GEORGE, DANIEL, ALICE, CARL, BENSON),
                 model.getFilteredPersonList());
     }
 

--- a/src/test/java/seedu/address/logic/commands/SortCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/SortCommandTest.java
@@ -173,13 +173,14 @@ public class SortCommandTest {
     @Test
     public void execute_sortByPhoneAscending_success() {
         String expectedMessage = String.format(SortCommand.MESSAGE_SUCCESS, "phone", "asc");
-        Comparator<Person> phoneComparator = Comparator.comparing(p -> p.getPhone().value);
+        Comparator<Person> phoneComparator = Comparator.comparingLong((Person p) ->
+                Long.parseLong(p.getPhone().value.replace("+", "")));
         SortCommand command = new SortCommand("phone", "asc");
         expectedModel.updatePersonListComparator(phoneComparator);
         assertCommandSuccess(command, model, expectedMessage, expectedModel);
-        // DANIEL (87652533), ALICE (94351253), ELLE (9482224), FIONA (9482427), GEORGE (9482442),
-        // CARL (95352563), BENSON (98765432)
-        assertEquals(Arrays.asList(DANIEL, ALICE, ELLE, FIONA, GEORGE, CARL, BENSON),
+        // DANIEL (87652533), ELLE (9482224), FIONA (9482427), GEORGE (9482442),
+        // ALICE (94351253), CARL (95352563), BENSON (98765432)
+        assertEquals(Arrays.asList(DANIEL, ELLE, FIONA, GEORGE, ALICE, CARL, BENSON),
                 model.getFilteredPersonList());
     }
 

--- a/src/test/java/seedu/address/logic/parser/SortCommandParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/SortCommandParserTest.java
@@ -148,6 +148,12 @@ public class SortCommandParserTest {
     }
 
     @Test
+    public void parse_extraPreambleText_throwsParseException() {
+        assertParseFailure(parser, " junk " + PREFIX_NAME,
+                String.format(MESSAGE_INVALID_COMMAND_FORMAT, SortCommand.MESSAGE_USAGE));
+    }
+
+    @Test
     public void parse_caseInsensitiveOrder_success() {
         SortCommand expectedCommand = new SortCommand("name", "asc");
 


### PR DESCRIPTION
## Summary

- Reject `sort` commands with extra preamble text before the attribute prefix (e.g. `sort junk n/` now errors instead of silently succeeding)
- Fix phone number sorting to use numerical order instead of lexicographical order, including correct handling of the `+` country code prefix
- Replace all remaining user-facing occurrences of "person" with "client" for consistent terminology across all commands and error messages
- Fix missing space between `[l/LOCATION]` and `[t/TAG]` in the `add` command usage message shown by `help add`

## Closes

Closes #316
Closes #330
Closes #336
Closes #359

## Test plan

- [ ] `sort junk n/` returns an invalid format error
- [ ] `sort n/` still works normally
- [ ] `sort p/ o/asc` sorts phone numbers numerically (e.g. 9482224 before 94351253, and +65... prefix handled correctly)
- [ ] `help add` displays `[l/LOCATION] [t/TAG]...` with a space between them
- [ ] `help status`, `help delete`, `help find`, `help view`, `help log`, `help sort` all use "client" consistently
- [ ] `status 1 s/inactive` success message says "Updated status of Client: ..."
- [ ] Adding a duplicate client shows "This client already exists in PowerRoster."
- [ ] Loading a corrupt data file shows "Client's ... field is missing!" / "Clients list contains duplicate client(s)."