### PR TITLE
Fix PE-D bugs: tab whitespace rejection and case-sensitive duplicate name detection

### DIFF
--- a/src/main/java/seedu/address/logic/parser/ArgumentTokenizer.java
+++ b/src/main/java/seedu/address/logic/parser/ArgumentTokenizer.java
@@ -24,6 +24,7 @@ public class ArgumentTokenizer {
      * @return           ArgumentMultimap object that maps prefixes to their arguments
      */
     public static ArgumentMultimap tokenize(String argsString, Prefix... prefixes) {
+        argsString = argsString.replaceAll("\\s", " ");
         List<PrefixPosition> positions = findAllPrefixPositions(argsString, prefixes);
         return extractArguments(argsString, positions);
     }

--- a/src/main/java/seedu/address/model/person/Person.java
+++ b/src/main/java/seedu/address/model/person/Person.java
@@ -307,7 +307,7 @@ public class Person {
         }
 
         return otherPerson != null
-                && otherPerson.getName().equals(getName());
+                && otherPerson.getName().fullName.equalsIgnoreCase(getName().fullName);
     }
 
     /**

--- a/src/test/java/seedu/address/logic/parser/ArgumentTokenizerTest.java
+++ b/src/test/java/seedu/address/logic/parser/ArgumentTokenizerTest.java
@@ -137,6 +137,15 @@ public class ArgumentTokenizerTest {
     }
 
     @Test
+    public void tokenize_tabSeparators_treatedAsWhitespace() {
+        // Tab before prefix should be recognised the same as a space
+        String argsString = " p/value1\t-t value2";
+        ArgumentMultimap argMultimap = ArgumentTokenizer.tokenize(argsString, pSlash, dashT);
+        assertArgumentPresent(argMultimap, pSlash, "value1");
+        assertArgumentPresent(argMultimap, dashT, "value2");
+    }
+
+    @Test
     public void equalsMethod() {
         Prefix aaa = new Prefix("aaa");
 

--- a/src/test/java/seedu/address/model/person/PersonTest.java
+++ b/src/test/java/seedu/address/model/person/PersonTest.java
@@ -43,9 +43,9 @@ public class PersonTest {
         editedAlice = new PersonBuilder(ALICE).withName(VALID_NAME_BOB).build();
         assertFalse(ALICE.isSamePerson(editedAlice));
 
-        // name differs in case, all other attributes same -> returns false
+        // name differs in case, all other attributes same -> returns true (case-insensitive)
         Person editedBob = new PersonBuilder(BOB).withName(VALID_NAME_BOB.toLowerCase()).build();
-        assertFalse(BOB.isSamePerson(editedBob));
+        assertTrue(BOB.isSamePerson(editedBob));
 
         // name has trailing spaces, all other attributes same -> returns true after normalization
         String nameWithTrailingSpaces = VALID_NAME_BOB + " ";


### PR DESCRIPTION
## Summary

- Normalise all whitespace (tabs, etc.) to spaces before tokenizing command arguments, so commands like `add n/Alice	g/F ...` with tab separators are accepted instead of rejected
- Fix duplicate client detection to be case-insensitive for names, so adding "john doe" when "John Doe" already exists is correctly blocked

## Closes

Closes #347
Closes #356

## Test plan

- [ ] `add n/Alice g/F dob/01/01/1990 p/90000001 e/alice@example.com a/Addr` with tab characters between fields succeeds
- [ ] `add n/john doe g/M dob/01/01/1990 p/98765432 e/johndoe@example.com a/123 Street` is rejected with duplicate client warning when "John Doe" already exists
- [ ] `add n/JOHN DOE g/M dob/01/01/1990 p/98765432 e/johndoe@example.com a/123 Street` is similarly rejected
- [ ] Adding a client with a genuinely different name (e.g. "Jane Doe") still succeeds
- [ ] All existing commands continue to work normally with regular space-separated input