### PR TITLE
Separate activity diagrams for log and last operations

### DIFF
--- a/docs/diagrams/WorkoutLogActivityDiagram.puml
+++ b/docs/diagrams/WorkoutLogActivityDiagram.puml
@@ -36,6 +36,7 @@ else (no)
 endif
 stop
 
+start
 :Trainer executes last INDEX;
 if (INDEX valid?) then (yes)
   if (Client has prior logs?) then (yes)

--- a/docs/diagrams/WorkoutLogActivityDiagram.puml
+++ b/docs/diagrams/WorkoutLogActivityDiagram.puml
@@ -34,8 +34,9 @@ if (INDEX valid in filtered list?) then (yes)
 else (no)
   :Return invalid-index error\nor format error;
 endif
+stop
 
-:Trainer may execute last INDEX;
+:Trainer executes last INDEX;
 if (INDEX valid?) then (yes)
   if (Client has prior logs?) then (yes)
     :Show most recent session details;


### PR DESCRIPTION
This pull request does the following:
- Separates the activity diagram used to detail log and last operations into two activity diagrams, one for each command.

Closes #343 