### PR TITLE
Fix duplicate client detection to require both matching name and phone number

### DIFF
--- a/docs/UserGuide.md
+++ b/docs/UserGuide.md
@@ -101,7 +101,7 @@ Format: `add n/NAME g/GENDER dob/DATE_OF_BIRTH p/PHONE_NUMBER e/EMAIL_ADDRESS a/
 * `NAME` must start with an alphanumeric character and end with an alphanumeric character or period (`.`).
 * `NAME` can contain alphanumeric characters, spaces, apostrophes (`'`), periods (`.`), and hyphens (`-`).
 * Other names with characters not supported like José Muñoz or 小明 should be replaced with suitable characters.
-* `NAME` is case-insensitive for duplicate detection (e.g. "John Doe" and "john doe" are treated as the same client)
+* Two clients are considered duplicates only if they share the same name (case-insensitive) **and** the same phone number. This means clients with the same name but different phone numbers can both be added (e.g. two clients both named "Ashley Tan" with different phone numbers are treated as different clients).
 * `EMAIL_ADDRESS` must follow the rules below (format: `local-part@domain`, e.g. `alex@example.com`):
   * Local-part (before `@`)
     * Uses letters, digits, and `+`, `_`, `.`, `-`

--- a/docs/UserGuide.md
+++ b/docs/UserGuide.md
@@ -101,7 +101,7 @@ Format: `add n/NAME g/GENDER dob/DATE_OF_BIRTH p/PHONE_NUMBER e/EMAIL_ADDRESS a/
 * `NAME` must start with an alphanumeric character and end with an alphanumeric character or period (`.`).
 * `NAME` can contain alphanumeric characters, spaces, apostrophes (`'`), periods (`.`), and hyphens (`-`).
 * Other names with characters not supported like José Muñoz or 小明 should be replaced with suitable characters.
-* Two clients are considered duplicates only if they share the same name (case-insensitive) **and** the same phone number. This means clients with the same name but different phone numbers can both be added (e.g. two clients both named "Ashley Tan" with different phone numbers are treated as different clients).
+* Two clients are considered duplicates only if they share the same name (case-insensitive) **and** the same phone number. This means clients with the same name but different phone numbers can both be added (e.g. two clients both named "Ashley Tan" with different phone numbers are treated as different clients). Phone numbers are not treated as unique identifiers on their own, as clients may share a number (e.g. using a family member's contact).
 * `EMAIL_ADDRESS` must follow the rules below (format: `local-part@domain`, e.g. `alex@example.com`):
   * Local-part (before `@`)
     * Uses letters, digits, and `+`, `_`, `.`, `-`

--- a/src/main/java/seedu/address/model/person/Person.java
+++ b/src/main/java/seedu/address/model/person/Person.java
@@ -305,7 +305,7 @@ public class Person {
     }
 
     /**
-     * Returns true if both persons have the same name.
+     * Returns true if both persons have the same name (case-insensitive) and phone number.
      * This defines a weaker notion of equality between two persons.
      */
     public boolean isSamePerson(Person otherPerson) {
@@ -314,7 +314,8 @@ public class Person {
         }
 
         return otherPerson != null
-                && otherPerson.getName().fullName.equalsIgnoreCase(getName().fullName);
+                && otherPerson.getName().fullName.equalsIgnoreCase(getName().fullName)
+                && otherPerson.getPhone().equals(getPhone());
     }
 
     /**

--- a/src/test/java/seedu/address/model/person/PersonTest.java
+++ b/src/test/java/seedu/address/model/person/PersonTest.java
@@ -33,11 +33,15 @@ public class PersonTest {
         // null -> returns false
         assertFalse(ALICE.isSamePerson(null));
 
-        // same name, all other attributes different -> returns true
+        // same name and phone, other attributes different -> returns true
         Person editedAlice = new PersonBuilder(ALICE).withGender(VALID_GENDER_BOB)
-                .withPhone(VALID_PHONE_BOB).withEmail(VALID_EMAIL_BOB)
+                .withEmail(VALID_EMAIL_BOB)
                 .withAddress(VALID_ADDRESS_BOB).withTags(VALID_TAG_HUSBAND).build();
         assertTrue(ALICE.isSamePerson(editedAlice));
+
+        // same name, different phone -> returns false
+        editedAlice = new PersonBuilder(ALICE).withPhone(VALID_PHONE_BOB).build();
+        assertFalse(ALICE.isSamePerson(editedAlice));
 
         // different name, all other attributes same -> returns false
         editedAlice = new PersonBuilder(ALICE).withName(VALID_NAME_BOB).build();


### PR DESCRIPTION
## Summary

- Fix duplicate detection to require both the same name (case-insensitive) and the same phone number, instead of name alone
- This allows two real-world clients who share the same name but have different phone numbers to both be added (e.g. two clients named "Ashley Tan" with different numbers)
- "john doe" and "John Doe" with the same phone number are still correctly blocked as duplicates
- Update UG to document the new duplicate detection rule

## Closes

Closes #315

## Test plan

- [x] `add n/Ashley Tan ... p/91234567 ...` followed by `add n/Ashley Tan ... p/98765432 ...` — both succeed
- [x] `add n/Ashley Tan ... p/91234567 ...` followed by `add n/ashley tan ... p/91234567 ...` — second is blocked as duplicate
- [x] `add n/John Doe ... p/91234567 ...` followed by `add n/Jane Doe ... p/91234567 ...` — both succeed (different names)
- [x] UG `add` section documents the name + phone duplicate rule with an example